### PR TITLE
fix: harden currency-codes updater reliability

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,9 @@ on:
   # Allows manual triggering of the workflow
   workflow_dispatch: 
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
+++ b/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
@@ -1,0 +1,7 @@
+# Update Script Maintenance Report
+
+Date: 2026-03-03
+
+- Ran `scripts/runall.sh` successfully to validate current update pipeline.
+- Hardened XML downloads in `scripts/runall.sh` with `curl --fail --silent --show-error --location`.
+- Added `permissions: contents: write` in `.github/workflows/actions.yml` for scheduled push reliability.

--- a/scripts/runall.sh
+++ b/scripts/runall.sh
@@ -27,8 +27,8 @@ if [ ! -d ./cache ]; then
   mkdir cache
 fi;
 echo Downloading XML files...
-curl -s -o cache/a1.xml "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml"
-curl -s -o cache/a2.xml "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-three.xml"
+curl --fail --silent --show-error --location -o cache/a1.xml "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml"
+curl --fail --silent --show-error --location -o cache/a2.xml "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-three.xml"
 
 # write headers
 echo "Entity,Currency,AlphabeticCode,NumericCode,MinorUnit,WithdrawalDate" > ${outfile}


### PR DESCRIPTION
## Summary
- hardened SIX XML downloads in `scripts/runall.sh` with `curl --fail --silent --show-error --location`
- added `permissions: contents: write` so scheduled workflow commits can push reliably
- added `UPDATE_SCRIPT_MAINTENANCE_REPORT.md` at repo root

## Validation
- `scripts/runall.sh`